### PR TITLE
chore: bump remaining @1.0.0 example refs to @2.0.0 [IOS-ORB-V2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and executors for building, testing, and deploying iOS/macOS apps.
 version: 2.1
 
 orbs:
-  ios: kevnm67/ios-orb@1.0.0
+  ios: kevnm67/ios-orb@2.0.0
 
 workflows:
   build-test:
@@ -156,7 +156,7 @@ Run tests with Code Climate coverage (legacy).
 version: 2.1
 
 orbs:
-  ios: kevnm67/ios-orb@1.0.0
+  ios: kevnm67/ios-orb@2.0.0
 
 jobs:
   setup:

--- a/src/examples/xcodegen_workflow.yml
+++ b/src/examples/xcodegen_workflow.yml
@@ -5,7 +5,7 @@ description: >
 usage:
     version: 2.1
     orbs:
-        ios: kevnm67/ios-orb@1.0.0
+        ios: kevnm67/ios-orb@2.0.0
     jobs:
         setup:
             executor:


### PR DESCRIPTION
## Summary

Aligns the last two `@1.0.0` references with the `@2.0.0` examples already in the codebase. Required to pass orb-tools/review's RC011 ("examples must showcase current major version") when tagging v2.0.0.

## Changes

- \`README.md\` — quick-start + PR workflow example: \`@1.0.0\` → \`@2.0.0\`
- \`src/examples/xcodegen_workflow.yml\` — \`@1.0.0\` → \`@2.0.0\`

5 other examples and \`src/README.md\` were already at @2.0.0.

## Test Plan

- [ ] CI green (lint, pack, review, shellcheck)
- [ ] After merge: tag \`v2.0.0\` from main → triggers \`orb-tools/publish\` with \`pub_type: production\`
- [ ] Verify \`kevnm67/ios-orb@2.0.0\` appears in CircleCI orb registry