### PR TITLE
fix(examples): alias orb as ios-orb so RC011 resolves the version [IOS-ORB-V2]

### DIFF
--- a/src/examples/full_workflow.yml
+++ b/src/examples/full_workflow.yml
@@ -6,31 +6,31 @@ description: >
 usage:
     version: 2.1
     orbs:
-        ios: kevnm67/ios-orb@2.0.0
+        ios-orb: kevnm67/ios-orb@2.0.0
     workflows:
         pr:
             when:
                 not:
                     equal: [main, << pipeline.git.branch >>]
             jobs:
-                - ios/run_with_setup:
+                - ios-orb/run_with_setup:
                       name: setup
                       xcode_version: 26.3.0
                       xcode_project: MyApp
                       scripts:
-                          - ios/install_tools:
+                          - ios-orb/install_tools:
                                 tools: xcodegen swiftlint
-                          - ios/xcodegen
-                - ios/run_with_setup:
+                          - ios-orb/xcodegen
+                - ios-orb/run_with_setup:
                       name: lint
                       attach_workspace: true
                       checkout: false
                       scripts:
-                          - ios/swiftlint:
+                          - ios-orb/swiftlint:
                                 strict: true
                       requires:
                           - setup
-                - ios/test:
+                - ios-orb/test:
                       name: test
                       xcode_version: 26.3.0
                       xcode_project: MyApp
@@ -41,22 +41,22 @@ usage:
             when:
                 equal: [main, << pipeline.git.branch >>]
             jobs:
-                - ios/run_with_setup:
+                - ios-orb/run_with_setup:
                       name: setup
                       xcode_version: 26.3.0
                       xcode_project: MyApp
                       scripts:
-                          - ios/install_tools:
+                          - ios-orb/install_tools:
                                 tools: xcodegen swiftlint
-                          - ios/xcodegen
-                - ios/test:
+                          - ios-orb/xcodegen
+                - ios-orb/test:
                       name: test
                       xcode_version: 26.3.0
                       xcode_project: MyApp
                       lane: test
                       requires:
                           - setup
-                - ios/run_with_setup:
+                - ios-orb/run_with_setup:
                       name: tag-release
                       attach_workspace: true
                       checkout: false

--- a/src/examples/multi_platform.yml
+++ b/src/examples/multi_platform.yml
@@ -5,19 +5,19 @@ description: >
 usage:
     version: 2.1
     orbs:
-        ios: kevnm67/ios-orb@2.0.0
+        ios-orb: kevnm67/ios-orb@2.0.0
     workflows:
         multi-platform:
             jobs:
-                - ios/run_with_setup:
+                - ios-orb/run_with_setup:
                       name: setup
                       xcode_version: 26.3.0
                       xcode_project: MyApp
                       scripts:
-                          - ios/install_tools:
+                          - ios-orb/install_tools:
                                 tools: xcodegen
-                          - ios/xcodegen
-                - ios/run_with_setup:
+                          - ios-orb/xcodegen
+                - ios-orb/run_with_setup:
                       name: test-ios
                       attach_workspace: true
                       checkout: false
@@ -36,7 +36,7 @@ usage:
                                 path: test-results
                       requires:
                           - setup
-                - ios/run_with_setup:
+                - ios-orb/run_with_setup:
                       name: test-macos
                       attach_workspace: true
                       checkout: false

--- a/src/examples/run_tests.yml
+++ b/src/examples/run_tests.yml
@@ -4,11 +4,11 @@ description: >
 usage:
     version: 2.1
     orbs:
-        ios: kevnm67/ios-orb@2.0.0
+        ios-orb: kevnm67/ios-orb@2.0.0
     workflows:
         test:
             jobs:
-                - ios/run_with_setup:
+                - ios-orb/run_with_setup:
                       name: test
                       xcode_version: 26.3.0
                       scripts:

--- a/src/examples/spm_workflow.yml
+++ b/src/examples/spm_workflow.yml
@@ -5,11 +5,11 @@ description: >
 usage:
     version: 2.1
     orbs:
-        ios: kevnm67/ios-orb@2.0.0
+        ios-orb: kevnm67/ios-orb@2.0.0
     workflows:
         ci:
             jobs:
-                - ios/run_with_setup:
+                - ios-orb/run_with_setup:
                       name: build-and-test
                       xcode_version: 26.3.0
                       scripts:

--- a/src/examples/xcode_workflow.yml
+++ b/src/examples/xcode_workflow.yml
@@ -6,25 +6,25 @@ description: >
 usage:
     version: 2.1
     orbs:
-        ios: kevnm67/ios-orb@2.0.0
+        ios-orb: kevnm67/ios-orb@2.0.0
     workflows:
         build-test:
             jobs:
-                - ios/run_with_setup:
+                - ios-orb/run_with_setup:
                       name: setup
                       xcode_version: 26.3.0
                       xcode_project: MyApp
                       scripts:
-                          - ios/install_tools:
+                          - ios-orb/install_tools:
                                 tools: xcodegen swiftlint
-                          - ios/xcodegen
-                - ios/test:
+                          - ios-orb/xcodegen
+                - ios-orb/test:
                       name: test
                       xcode_version: 26.3.0
                       xcode_project: MyApp
                       lane: test
                       pretest_steps:
-                          - ios/swiftlint:
+                          - ios-orb/swiftlint:
                                 strict: true
                       requires:
                           - setup

--- a/src/examples/xcodegen_workflow.yml
+++ b/src/examples/xcodegen_workflow.yml
@@ -5,16 +5,16 @@ description: >
 usage:
     version: 2.1
     orbs:
-        ios: kevnm67/ios-orb@2.0.0
+        ios-orb: kevnm67/ios-orb@2.0.0
     jobs:
         setup:
             executor:
-                name: ios/macos
+                name: ios-orb/macos
             steps:
                 - checkout
-                - ios/install_tools:
+                - ios-orb/install_tools:
                       tools: xcodegen swiftlint
-                - ios/xcodegen
+                - ios-orb/xcodegen
                 - run:
                       name: Install gems
                       command: |
@@ -26,11 +26,11 @@ usage:
                           - .
         test:
             executor:
-                name: ios/macos
+                name: ios-orb/macos
             steps:
                 - attach_workspace:
                       at: .
-                - ios/lane:
+                - ios-orb/lane:
                       named: test
                 - store_test_results:
                       path: test-results


### PR DESCRIPTION
## Summary
- orb-tools review RC011 looks up `usage.orbs["ios-orb"]` on production tags; examples aliased the orb as `ios`, so the lookup returned null and the v2.0.0 tag pipeline failed `Usage example Orb version: "null"`.
- Rename the alias to `ios-orb` (and all `ios/` step refs) across the 6 usage examples. Packed orb validates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)