### PR TITLE
fix(swiftlint): guard empty ARGS expansion under set -u (bash 3.2) [IOS-ORB-V2]

### DIFF
--- a/src/scripts/swiftlint_run.sh
+++ b/src/scripts/swiftlint_run.sh
@@ -8,9 +8,14 @@ set -euo pipefail
 
 ARGS=()
 
-if [ "${SWIFTLINT_STRICT}" = "true" ]; then
-    ARGS+=("--strict")
-fi
+# Boolean parameters can render as "true" or "1" depending on how the
+# command was invoked — accept both.
+case "${SWIFTLINT_STRICT:-false}" in
+    true | 1)
+        ARGS+=("--strict")
+        ;;
+    *) ;;
+esac
 
 if [ -n "${SWIFTLINT_CONFIG:-}" ]; then
     ARGS+=("--config" "${SWIFTLINT_CONFIG}")
@@ -20,5 +25,7 @@ if [ -n "${SWIFTLINT_REPORTER:-}" ]; then
     ARGS+=("--reporter" "${SWIFTLINT_REPORTER}")
 fi
 
-echo "→ Running: swiftlint ${ARGS[*]}"
-swiftlint "${ARGS[@]}"
+# macOS ships bash 3.2, where expanding an EMPTY array under `set -u`
+# raises "ARGS[*]: unbound variable". Use the ${arr[@]+...} guard.
+echo "→ Running: swiftlint ${ARGS[*]:-}"
+swiftlint ${ARGS[@]+"${ARGS[@]}"}


### PR DESCRIPTION
## Summary
- TrailSync lint job failed: `/bin/bash: line 22: ARGS[*]: unbound variable` — macOS bash 3.2 treats an empty array as unset under `set -u`
- Accept both `true`/`1` renderings of the strict boolean and use the `${arr[@]+"${arr[@]}"}` expansion guard
- Other scripts (`match_signing.sh`, `xcodegen_generate.sh`) always seed `ARGS` non-empty, so they're unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)