### PR TITLE
ci: create GitHub Release automatically on every production orb tag [IOS-ORB-V3]

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,34 @@
+---
+name: GitHub Release on Orb Tag
+
+# Keep GitHub Releases in lockstep with orb registry publishes: every
+# production tag (vX.Y.Z) that triggers the CircleCI orb publish also
+# gets a GitHub Release with generated notes, marked Latest.
+
+on:
+    push:
+        tags:
+            - v[0-9]+.[0-9]+.[0-9]+
+
+permissions:
+    contents: write
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Create GitHub Release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  TAG: ${{ github.ref_name }}
+              run: |
+                  if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" &>/dev/null; then
+                    echo "Release $TAG already exists — nothing to do."
+                    exit 0
+                  fi
+                  gh release create "$TAG" \
+                    --repo "$GITHUB_REPOSITORY" \
+                    --verify-tag \
+                    --latest \
+                    --title "$TAG" \
+                    --generate-notes


### PR DESCRIPTION
GitHub Releases drifted from the orb registry (registry at 3.0.0,
Releases stuck at v0.0.2 — v2.0.0/v2.0.1/v3.0.0 backfilled manually).
This workflow makes the invariant structural: any vX.Y.Z tag push that
triggers the CircleCI publish also creates a generated-notes GitHub
Release marked Latest. Idempotent if the release already exists.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
