### PR TITLE
fix(security): resolve zizmor findings — SHA-pin actions, drop pull_request_target, no credential persistence [IOS-ORB-V3]

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,39 +1,41 @@
+---
 name: Claude Code Action
 on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-  issues:
-    types: [opened, assigned, labeled]
-  pull_request_review:
-    types: [submitted]
-  pull_request:
-    types: [opened, synchronize]
+    issue_comment:
+        types: [created]
+    pull_request_review_comment:
+        types: [created]
+    issues:
+        types: [opened, assigned, labeled]
+    pull_request_review:
+        types: [submitted]
+    pull_request:
+        types: [opened, synchronize]
 
 jobs:
-  claude-response:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
+    claude-response:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+            issues: write
+            id-token: write
+            actions: read
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+              with:
+                  persist-credentials: false
+                  fetch-depth: 0
 
-      - name: Run Claude Code Action
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+            - name: Run Claude Code Action
+              id: claude
+              uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1
+              with:
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Customize the trigger phrase (default: @claude)
-          trigger_phrase: "@claude"
+                  trigger_phrase: '@claude'
           # Optional: Use Claude Opus 4.5
           # claude_args: "--model claude-opus-4-5-20251101"
           # Optional: Limit allowed tools

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,6 +1,6 @@
 ---
 name: Labeler
-on: [pull_request_target]
+on: [pull_request]
 jobs:
     labeler:
         permissions:
@@ -8,4 +8,4 @@ jobs:
             pull-requests: write
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/labeler@v6
+            - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -16,12 +16,13 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
               with:
+                  persist-credentials: false
                   fetch-depth: 0
 
             - name: Review PR with Claude
-              uses: anthropics/claude-code-action@v1
+              uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   prompt: Review this PR for code quality, security, and completeness. Check for potential issues and suggest improvements.


### PR DESCRIPTION
qlty/zizmor flagged: unpinned-uses (High x2), dangerous-triggers (High),
artipacked (Medium x2).
- actions/checkout, actions/labeler, anthropics/claude-code-action pinned
  to full commit SHAs with version comments
- label.yml: pull_request_target -> pull_request (no fork PRs; labeler v6
  works with pull-requests: write on the standard trigger)
- persist-credentials: false on every checkout

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
