### PR TITLE
test: bats + kcov coverage for orb scripts, publish to qlty [IOS-ORB-V3]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,16 @@ jobs:
             - image: cimg/base:current
         steps:
             - checkout
+            - restore_cache:
+                  keys:
+                      - kcov-v43-{{ arch }}
             - run:
                   name: Install bats-core and kcov
                   command: ./scripts/ci/install-script-test-deps.sh
+            - save_cache:
+                  key: kcov-v43-{{ arch }}
+                  paths:
+                      - ~/kcov
             - run:
                   name: Run bats + kcov coverage
                   command: ./scripts/ci/run-script-tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,30 @@ version: 2.1
 setup: true
 orbs:
     orb-tools: circleci/orb-tools@12.4.0
+    qlty: qltysh/qlty-orb@0.1.1
     shellcheck: circleci/shellcheck@3.4.0
 
 filters: &filters
     tags:
         only: /.*/
+
+jobs:
+    script_tests:
+        docker:
+            - image: cimg/base:current
+        steps:
+            - checkout
+            - run:
+                  name: Install bats-core and kcov
+                  command: |
+                      sudo apt-get update -qq
+                      sudo apt-get install -y bats kcov
+            - run:
+                  name: Run bats + kcov coverage
+                  command: ./scripts/ci/run-script-tests.sh
+            - qlty/coverage_publish:
+                  files: coverage/cobertura.xml
+                  format: cobertura
 
 workflows:
     lint-pack:
@@ -22,9 +41,12 @@ workflows:
                   filters: *filters
             - shellcheck/check:
                   filters: *filters
+            - script_tests:
+                  context: qlty-credentials
+                  filters: *filters
             - orb-tools/continue:
                   pipeline_number: << pipeline.number >>
                   vcs_type: << pipeline.project.type >>
                   orb_name: ios-orb
-                  requires: [orb-tools/lint, orb-tools/pack, orb-tools/review, shellcheck/check]
+                  requires: [orb-tools/lint, orb-tools/pack, orb-tools/review, shellcheck/check, script_tests]
                   filters: *filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,7 @@ jobs:
             - checkout
             - run:
                   name: Install bats-core and kcov
-                  command: |
-                      sudo apt-get update -qq
-                      sudo apt-get install -y bats kcov
+                  command: ./scripts/ci/install-script-test-deps.sh
             - run:
                   name: Run bats + kcov coverage
                   command: ./scripts/ci/run-script-tests.sh

--- a/scripts/ci/install-script-test-deps.sh
+++ b/scripts/ci/install-script-test-deps.sh
@@ -1,11 +1,29 @@
 #!/bin/bash
 set -euo pipefail
 
-# Install bats-core + kcov on a cimg/base (Ubuntu) executor.
-# kcov lives in the 'universe' component, which isn't enabled by default.
-sudo add-apt-repository -y universe
+# Install bats-core + kcov on a cimg/base (Ubuntu 24.04) executor.
+# kcov was dropped from Ubuntu 24.04 repos, so build it from a pinned
+# source release. The CI job caches KCOV_PREFIX keyed on KCOV_VERSION.
+
+KCOV_VERSION="${KCOV_VERSION:-v43}"
+KCOV_PREFIX="${KCOV_PREFIX:-$HOME/kcov}"
+
 sudo apt-get update -qq
-sudo apt-get install -y bats kcov
+sudo apt-get install -y bats cmake g++ binutils-dev libssl-dev \
+    libcurl4-openssl-dev libdw-dev libiberty-dev zlib1g-dev
+
+if [ ! -x "${KCOV_PREFIX}/bin/kcov" ]; then
+    workdir="$(mktemp -d)"
+    curl -fsSL "https://github.com/SimonKagstrom/kcov/archive/refs/tags/${KCOV_VERSION}.tar.gz" \
+        | tar -xz -C "$workdir" --strip-components=1
+    cmake -S "$workdir" -B "$workdir/build" \
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$KCOV_PREFIX"
+    make -C "$workdir/build" -j"$(nproc)"
+    make -C "$workdir/build" install
+    rm -rf "$workdir"
+fi
+
+sudo ln -sf "${KCOV_PREFIX}/bin/kcov" /usr/local/bin/kcov
 
 bats --version
 kcov --version | head -1

--- a/scripts/ci/install-script-test-deps.sh
+++ b/scripts/ci/install-script-test-deps.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install bats-core + kcov on a cimg/base (Ubuntu) executor.
+# kcov lives in the 'universe' component, which isn't enabled by default.
+sudo add-apt-repository -y universe
+sudo apt-get update -qq
+sudo apt-get install -y bats kcov
+
+bats --version
+kcov --version | head -1

--- a/scripts/ci/run-script-tests.sh
+++ b/scripts/ci/run-script-tests.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run bats tests for orb scripts with kcov coverage.
+# Designed for Linux CI (kcov + bats-core available via apt / package manager).
+# Locally: just run `bats tests/scripts` — kcov is not required on macOS.
+#
+# Usage: ./scripts/ci/run-script-tests.sh
+# Output: coverage/cobertura.xml  (merged cobertura from all bats files)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COVERAGE_DIR="${REPO_ROOT}/coverage"
+KCOV_OUT="${COVERAGE_DIR}/kcov"
+TESTS_DIR="${REPO_ROOT}/tests/scripts"
+SRC_DIR="${REPO_ROOT}/src/scripts"
+
+mkdir -p "${COVERAGE_DIR}" "${KCOV_OUT}"
+
+if ! command -v kcov &>/dev/null; then
+    echo "ERROR: kcov not found. Install via apt-get install kcov (Ubuntu) or brew install kcov (macOS)." >&2
+    exit 1
+fi
+
+if ! command -v bats &>/dev/null; then
+    echo "ERROR: bats not found. Install via apt-get install bats or brew install bats-core." >&2
+    exit 1
+fi
+
+echo "-> Running bats tests with kcov instrumentation..."
+echo "   Source dir: ${SRC_DIR}"
+echo "   Tests dir:  ${TESTS_DIR}"
+echo "   Output dir: ${KCOV_OUT}"
+
+# Run kcov per bats file for finer-grained per-file coverage reports
+MERGE_DIRS=()
+for bats_file in "${TESTS_DIR}"/*.bats; do
+    base="$(basename "${bats_file}" .bats)"
+    out_dir="${KCOV_OUT}/${base}"
+    mkdir -p "${out_dir}"
+    echo "   -> kcov ${base}..."
+    kcov \
+        --include-path="${SRC_DIR}" \
+        --exclude-pattern=".bats" \
+        "${out_dir}" \
+        bats "${bats_file}"
+    MERGE_DIRS+=("${out_dir}")
+done
+
+# Merge all individual reports into a single directory
+MERGED_DIR="${KCOV_OUT}/merged"
+echo "-> Merging coverage reports..."
+kcov --merge "${MERGED_DIR}" "${MERGE_DIRS[@]}"
+
+# Locate cobertura.xml from the merged output
+COBERTURA_SRC="$(find "${MERGED_DIR}" -name "cobertura.xml" | head -1)"
+if [[ -z "${COBERTURA_SRC}" ]]; then
+    echo "ERROR: cobertura.xml not found in ${MERGED_DIR}" >&2
+    exit 1
+fi
+
+cp "${COBERTURA_SRC}" "${COVERAGE_DIR}/cobertura.xml"
+echo "-> Coverage report: ${COVERAGE_DIR}/cobertura.xml"
+
+# Print a quick summary line from the merged HTML if available
+SUMMARY="$(find "${MERGED_DIR}" -name "*.json" | head -1)"
+if [[ -n "${SUMMARY}" ]]; then
+    echo "-> Merge summary available at: ${SUMMARY}"
+fi
+
+echo "-> Done."

--- a/src/scripts/export_spm_coverage.sh
+++ b/src/scripts/export_spm_coverage.sh
@@ -32,7 +32,7 @@ fi
 
 # Fallback: look for any test executable
 if [[ -z "${TEST_BINARY}" ]]; then
-    TEST_BINARY=$(find "${BUILD_DIR}" -type f -perm +111 -name "*Tests" 2>/dev/null | head -1)
+    TEST_BINARY=$(find "${BUILD_DIR}" -type f -perm -111 -name "*Tests" 2>/dev/null | head -1)
 fi
 
 if [[ -z "${TEST_BINARY}" ]]; then

--- a/tests/scripts/create_release_tag.bats
+++ b/tests/scripts/create_release_tag.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/create_release_tag.sh
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/create_release_tag.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+
+setup() {
+    export PATH="${STUBS}:${PATH}"
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+    unset VERSION_SOURCE
+}
+
+# git stub returns "v1.2.3" for describe and exits 1 for rev-parse (tag doesn't exist)
+# so the script should create v1.2.4
+
+@test "defaults to git-describe and increments patch" {
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Creating tag: v1.2.4"* ]]
+}
+
+@test "git-describe source creates correct tag" {
+    export VERSION_SOURCE="git-describe"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^git tag -a v1.2.4" "${STUB_CALL_LOG}"
+}
+
+@test "git-describe source pushes tag to origin" {
+    export VERSION_SOURCE="git-describe"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^git push origin v1.2.4$" "${STUB_CALL_LOG}"
+}
+
+@test "marketing-version reads MARKETING_VERSION from xcodebuild" {
+    export VERSION_SOURCE="marketing-version"
+    export PATH="${STUBS}:${PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    # xcodebuild stub outputs MARKETING_VERSION = 2.5.0
+    [[ "${output}" == *"Creating tag: v2.5.0"* ]]
+}
+
+@test "unknown version_source exits with error" {
+    export VERSION_SOURCE="invalid-source"
+    run bash "${SCRIPT}"
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"Unknown version_source"* ]]
+}
+
+@test "skips when tag already exists" {
+    # Override git stub to make rev-parse succeed for v1.2.4
+    TMPBIN="${BATS_TMPDIR}/bin_${BATS_TEST_NUMBER}"
+    mkdir -p "${TMPBIN}"
+    cat > "${TMPBIN}/git" << 'GITSTUB'
+#!/usr/bin/env bash
+echo "git stub: $*" >> "${STUB_CALL_LOG}"
+case "$*" in
+    "describe --tags --abbrev=0") echo "v1.2.3" ;;
+    "rev-parse v1.2.4") exit 0 ;;   # tag exists
+    *) echo "stub:git $*" ;;
+esac
+GITSTUB
+    chmod +x "${TMPBIN}/git"
+    export PATH="${TMPBIN}:${PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"already exists"* ]]
+}
+
+@test "marketing-version exits non-zero when MARKETING_VERSION empty" {
+    export VERSION_SOURCE="marketing-version"
+    # Override xcodebuild to return no MARKETING_VERSION line.
+    # The script's grep pipeline produces empty NEW_VERSION; set -euo pipefail may
+    # kill the script before the explicit error echo, so only assert exit status.
+    TMPBIN="${BATS_TMPDIR}/bin_${BATS_TEST_NUMBER}"
+    mkdir -p "${TMPBIN}"
+    cat > "${TMPBIN}/xcodebuild" << 'XSTUB'
+#!/usr/bin/env bash
+echo "    SOME_OTHER_SETTING = value"
+XSTUB
+    chmod +x "${TMPBIN}/xcodebuild"
+    export PATH="${TMPBIN}:/usr/bin:/bin:/usr/sbin:/sbin"
+    run bash "${SCRIPT}"
+    [ "${status}" -ne 0 ]
+}

--- a/tests/scripts/export_spm_coverage.bats
+++ b/tests/scripts/export_spm_coverage.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/export_spm_coverage.sh
+# Note: this script is non-fatal (exits 0 on missing data) so all error paths
+# should still return 0 with a warning message.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/export_spm_coverage.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+
+setup() {
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+    # Each test gets its own isolated root so profdata from one test
+    # doesn't leak into another test's `find BUILD_DIR/../` search.
+    TEST_ROOT="${BATS_TMPDIR}/t${BATS_TEST_NUMBER}"
+    WORK_DIR="${TEST_ROOT}/work"
+    mkdir -p "${WORK_DIR}"
+    cd "${WORK_DIR}"
+}
+
+@test "exits 0 with warning when swift --show-bin-path returns empty" {
+    TMPBIN="${TEST_ROOT}/bin"
+    mkdir -p "${TMPBIN}"
+    cat > "${TMPBIN}/swift" << 'SWIFTSTUB'
+#!/usr/bin/env bash
+echo ""
+SWIFTSTUB
+    chmod +x "${TMPBIN}/swift"
+    export PATH="${TMPBIN}:/usr/bin:/bin:/usr/sbin:/sbin"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Could not determine build directory"* ]]
+}
+
+@test "exits 0 with warning when build dir given but no profdata" {
+    TMPBIN="${TEST_ROOT}/bin"
+    BUILD_DIR="${TEST_ROOT}/build"
+    mkdir -p "${TMPBIN}" "${BUILD_DIR}"
+    # No profdata anywhere under TEST_ROOT
+    cat > "${TMPBIN}/swift" << SWIFTSTUB
+#!/usr/bin/env bash
+echo "${BUILD_DIR}"
+SWIFTSTUB
+    chmod +x "${TMPBIN}/swift"
+    export PATH="${TMPBIN}:/usr/bin:/bin:/usr/sbin:/sbin"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"No profdata file found"* ]]
+}
+
+@test "exits 0 with warning when profdata found but no test binary" {
+    TMPBIN="${TEST_ROOT}/bin"
+    BUILD_DIR="${TEST_ROOT}/build"
+    mkdir -p "${TMPBIN}" "${BUILD_DIR}"
+    # Place profdata one level up from BUILD_DIR (i.e. in TEST_ROOT)
+    touch "${BUILD_DIR}/../default.profdata"
+    cat > "${TMPBIN}/swift" << SWIFTSTUB
+#!/usr/bin/env bash
+echo "${BUILD_DIR}"
+SWIFTSTUB
+    chmod +x "${TMPBIN}/swift"
+    export PATH="${TMPBIN}:/usr/bin:/bin:/usr/sbin:/sbin"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"No test binary found"* ]]
+}
+
+@test "exports coverage when profdata and test binary present" {
+    TMPBIN="${TEST_ROOT}/bin"
+    BUILD_DIR="${TEST_ROOT}/build"
+    mkdir -p "${TMPBIN}" "${BUILD_DIR}"
+    # Create profdata
+    touch "${BUILD_DIR}/../default.profdata"
+    # Create a fake test executable
+    FAKE_BIN="${BUILD_DIR}/MyTests"
+    touch "${FAKE_BIN}"
+    chmod +x "${FAKE_BIN}"
+    cat > "${TMPBIN}/swift" << SWIFTSTUB
+#!/usr/bin/env bash
+echo "${BUILD_DIR}"
+SWIFTSTUB
+    chmod +x "${TMPBIN}/swift"
+    # xcrun must output DA lines to stdout so the script can redirect to coverage.lcov
+    cat > "${TMPBIN}/xcrun" << 'XSTUB'
+#!/usr/bin/env bash
+echo "xcrun $*" >> "${STUB_CALL_LOG:-/tmp/xcrun_stub.log}"
+echo "DA:1,1"
+echo "DA:2,0"
+XSTUB
+    chmod +x "${TMPBIN}/xcrun"
+    export PATH="${TMPBIN}:/usr/bin:/bin:/usr/sbin:/sbin"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Coverage exported"* ]]
+}

--- a/tests/scripts/export_xcode_coverage.bats
+++ b/tests/scripts/export_xcode_coverage.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/export_xcode_coverage.sh
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/export_xcode_coverage.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+
+setup() {
+    export PATH="${STUBS}:${PATH}"
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+    unset RESULT_BUNDLE_PATH
+    # Work in a temp dir so coverage.xml doesn't pollute repo
+    WORK_DIR="${BATS_TMPDIR}/work_${BATS_TEST_NUMBER}"
+    mkdir -p "${WORK_DIR}"
+    cd "${WORK_DIR}"
+}
+
+@test "exits 1 when result bundle not found" {
+    export RESULT_BUNDLE_PATH="NonExistent.xcresult"
+    run bash "${SCRIPT}"
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"not found"* ]]
+}
+
+@test "uses default bundle name TestResults.xcresult when env var unset" {
+    # No bundle dir exists -> should fail with 'not found'
+    unset RESULT_BUNDLE_PATH
+    run bash "${SCRIPT}"
+    [ "${status}" -ne 0 ]
+    [[ "${output}" == *"TestResults.xcresult"* ]]
+}
+
+@test "calls xcresultparser when bundle exists and xcresultparser in PATH" {
+    # Create a fake xcresult dir
+    BUNDLE="${WORK_DIR}/TestResults.xcresult"
+    mkdir -p "${BUNDLE}"
+    export RESULT_BUNDLE_PATH="${BUNDLE}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^xcresultparser" "${STUB_CALL_LOG}"
+}
+
+@test "xcresultparser receives --output-format cobertura flag" {
+    BUNDLE="${WORK_DIR}/TestResults.xcresult"
+    mkdir -p "${BUNDLE}"
+    export RESULT_BUNDLE_PATH="${BUNDLE}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "cobertura" "${STUB_CALL_LOG}"
+}
+
+@test "outputs coverage.xml message on success" {
+    BUNDLE="${WORK_DIR}/TestResults.xcresult"
+    mkdir -p "${BUNDLE}"
+    export RESULT_BUNDLE_PATH="${BUNDLE}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"coverage.xml"* ]]
+}
+
+@test "installs xcresultparser via brew when absent" {
+    # Use a brew stub that installs xcresultparser into TMPBIN so the subsequent
+    # call to xcresultparser in the script succeeds. Isolate PATH so the real
+    # Homebrew xcresultparser is invisible to `command -v`.
+    TMPBIN="${BATS_TMPDIR}/bin_${BATS_TEST_NUMBER}"
+    mkdir -p "${TMPBIN}"
+    XCRESULTPARSER_STUB="${STUBS}/xcresultparser"
+    STUB_CALL_LOG_REF="${STUB_CALL_LOG}"
+    # brew stub: on `brew install ...`, copy xcresultparser stub into TMPBIN
+    cat > "${TMPBIN}/brew" << BREWSTUB
+#!/usr/bin/env bash
+echo "brew \$*" >> "${STUB_CALL_LOG_REF}"
+# Simulate brew installing xcresultparser by dropping stub into TMPBIN
+cp "${XCRESULTPARSER_STUB}" "${TMPBIN}/xcresultparser"
+chmod +x "${TMPBIN}/xcresultparser"
+BREWSTUB
+    chmod +x "${TMPBIN}/brew"
+    BUNDLE="${WORK_DIR}/TestResults.xcresult"
+    mkdir -p "${BUNDLE}"
+    export RESULT_BUNDLE_PATH="${BUNDLE}"
+    # Strict PATH: TMPBIN first, no Homebrew, so real xcresultparser absent initially
+    export PATH="${TMPBIN}:/usr/bin:/bin:/usr/sbin:/sbin"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^brew install" "${STUB_CALL_LOG}"
+}

--- a/tests/scripts/install_tools.bats
+++ b/tests/scripts/install_tools.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/install_tools.sh
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/install_tools.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+SYSTEM_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+setup() {
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+}
+
+@test "reports already installed for tools present in PATH" {
+    export PATH="${STUBS}:${SYSTEM_PATH}"
+    # swiftlint and xcodegen are both in stubs/
+    export TOOLS="swiftlint xcodegen"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"already installed"* ]]
+}
+
+@test "calls brew install for missing tool" {
+    TMPBIN="${BATS_TMPDIR}/bin_${BATS_TEST_NUMBER}"
+    mkdir -p "${TMPBIN}"
+    cp "${STUBS}/brew" "${TMPBIN}/brew"
+    chmod +x "${TMPBIN}/brew"
+    export PATH="${TMPBIN}:${SYSTEM_PATH}"
+    export TOOLS="nonexistent_tool_xyz"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^brew install nonexistent_tool_xyz" "${STUB_CALL_LOG}"
+}
+
+@test "handles multiple tools: present ones skip, absent ones install" {
+    TMPBIN="${BATS_TMPDIR}/bin_${BATS_TEST_NUMBER}"
+    mkdir -p "${TMPBIN}"
+    cp "${STUBS}/brew" "${TMPBIN}/brew"
+    cp "${STUBS}/swiftlint" "${TMPBIN}/swiftlint"
+    chmod +x "${TMPBIN}/brew" "${TMPBIN}/swiftlint"
+    export PATH="${TMPBIN}:${SYSTEM_PATH}"
+    export TOOLS="swiftlint missing_tool_abc"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"already installed"* ]]
+    grep -q "^brew install missing_tool_abc" "${STUB_CALL_LOG}"
+}
+
+@test "TOOLS with a single tool that is present" {
+    export PATH="${STUBS}:${SYSTEM_PATH}"
+    export TOOLS="brew"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"already installed"* ]]
+}

--- a/tests/scripts/match_signing.bats
+++ b/tests/scripts/match_signing.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/match_signing.sh
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/match_signing.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+
+setup() {
+    export PATH="${STUBS}:${PATH}"
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+    unset MATCH_APP_IDENTIFIER
+    export MATCH_READONLY="false"
+}
+
+@test "runs bundle exec fastlane match adhoc" {
+    export MATCH_TYPES="adhoc"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^bundle exec fastlane match adhoc$" "${STUB_CALL_LOG}"
+}
+
+@test "adds --readonly when MATCH_READONLY=true" {
+    export MATCH_TYPES="appstore"
+    export MATCH_READONLY="true"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^bundle exec fastlane match appstore --readonly$" "${STUB_CALL_LOG}"
+}
+
+@test "does not add --readonly when MATCH_READONLY=false" {
+    export MATCH_TYPES="development"
+    export MATCH_READONLY="false"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    result=$(grep "^bundle exec fastlane match development" "${STUB_CALL_LOG}")
+    [[ "${result}" != *"--readonly"* ]]
+}
+
+@test "adds --app_identifier when MATCH_APP_IDENTIFIER is set" {
+    export MATCH_TYPES="adhoc"
+    export MATCH_APP_IDENTIFIER="com.example.app"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^bundle exec fastlane match adhoc --app_identifier com.example.app$" "${STUB_CALL_LOG}"
+}
+
+@test "does not add --app_identifier when MATCH_APP_IDENTIFIER is unset" {
+    export MATCH_TYPES="adhoc"
+    unset MATCH_APP_IDENTIFIER
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    result=$(grep "^bundle exec fastlane match adhoc" "${STUB_CALL_LOG}")
+    [[ "${result}" != *"--app_identifier"* ]]
+}
+
+@test "iterates multiple comma-separated types" {
+    export MATCH_TYPES="adhoc,appstore"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^bundle exec fastlane match adhoc$" "${STUB_CALL_LOG}"
+    grep -q "^bundle exec fastlane match appstore$" "${STUB_CALL_LOG}"
+}
+
+@test "trims whitespace from types" {
+    export MATCH_TYPES="adhoc, appstore"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^bundle exec fastlane match adhoc$" "${STUB_CALL_LOG}"
+    grep -q "^bundle exec fastlane match appstore$" "${STUB_CALL_LOG}"
+}
+
+@test "combines readonly + app_identifier + multiple types" {
+    export MATCH_TYPES="adhoc,appstore"
+    export MATCH_READONLY="true"
+    export MATCH_APP_IDENTIFIER="com.example.app"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^bundle exec fastlane match adhoc --readonly --app_identifier com.example.app$" "${STUB_CALL_LOG}"
+    grep -q "^bundle exec fastlane match appstore --readonly --app_identifier com.example.app$" "${STUB_CALL_LOG}"
+}

--- a/tests/scripts/swiftlint_install.bats
+++ b/tests/scripts/swiftlint_install.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/swiftlint_install.sh
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/swiftlint_install.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+# Minimal system PATH that has bash/test/etc but not Homebrew binaries
+SYSTEM_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+setup() {
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+}
+
+@test "skips brew when swiftlint already installed" {
+    # swiftlint stub is present in STUBS — appears installed
+    export PATH="${STUBS}:${SYSTEM_PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"already installed"* ]]
+}
+
+@test "calls brew install when swiftlint absent" {
+    # TMPBIN has brew but NOT swiftlint; system path excluded to prevent real swiftlint
+    TMPBIN="${BATS_TMPDIR}/bin_${BATS_TEST_NUMBER}"
+    mkdir -p "${TMPBIN}"
+    cp "${STUBS}/brew" "${TMPBIN}/brew"
+    chmod +x "${TMPBIN}/brew"
+    export PATH="${TMPBIN}:${SYSTEM_PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^brew install swiftlint" "${STUB_CALL_LOG}"
+}
+
+@test "outputs version when swiftlint found" {
+    export PATH="${STUBS}:${SYSTEM_PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"SwiftLint"* ]]
+}

--- a/tests/scripts/swiftlint_run.bats
+++ b/tests/scripts/swiftlint_run.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/swiftlint_run.sh
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/swiftlint_run.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+
+setup() {
+    export PATH="${STUBS}:${PATH}"
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+    # Unset env vars so each test starts clean
+    unset SWIFTLINT_STRICT SWIFTLINT_CONFIG SWIFTLINT_REPORTER
+}
+
+@test "runs swiftlint with no flags when all env vars unset" {
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    # log has "swiftlint " (with trailing space) or "swiftlint" when no args
+    grep -qE "^swiftlint\s*$" "${STUB_CALL_LOG}"
+}
+
+@test "adds --strict when SWIFTLINT_STRICT=true" {
+    export SWIFTLINT_STRICT=true
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^swiftlint --strict" "${STUB_CALL_LOG}"
+}
+
+@test "adds --strict when SWIFTLINT_STRICT=1" {
+    export SWIFTLINT_STRICT=1
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^swiftlint --strict" "${STUB_CALL_LOG}"
+}
+
+@test "no --strict when SWIFTLINT_STRICT=false" {
+    export SWIFTLINT_STRICT=false
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    result=$(cat "${STUB_CALL_LOG}")
+    [[ "${result}" != *"--strict"* ]]
+}
+
+@test "no --strict when SWIFTLINT_STRICT is empty string" {
+    export SWIFTLINT_STRICT=""
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    result=$(cat "${STUB_CALL_LOG}")
+    [[ "${result}" != *"--strict"* ]]
+}
+
+@test "adds --config when SWIFTLINT_CONFIG is set" {
+    export SWIFTLINT_CONFIG=".swiftlint.yml"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^swiftlint --config .swiftlint.yml" "${STUB_CALL_LOG}"
+}
+
+@test "adds --reporter when SWIFTLINT_REPORTER is set" {
+    export SWIFTLINT_REPORTER="junit"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^swiftlint --reporter junit" "${STUB_CALL_LOG}"
+}
+
+@test "combines strict + config + reporter" {
+    export SWIFTLINT_STRICT=true
+    export SWIFTLINT_CONFIG=".swiftlint.yml"
+    export SWIFTLINT_REPORTER="junit"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^swiftlint --strict --config .swiftlint.yml --reporter junit" "${STUB_CALL_LOG}"
+}
+
+@test "combines strict=1 + reporter only (no config)" {
+    export SWIFTLINT_STRICT=1
+    export SWIFTLINT_REPORTER="xcode"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^swiftlint --strict --reporter xcode" "${STUB_CALL_LOG}"
+}
+
+@test "does not pass --config when SWIFTLINT_CONFIG is empty" {
+    export SWIFTLINT_CONFIG=""
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    result=$(cat "${STUB_CALL_LOG}")
+    [[ "${result}" != *"--config"* ]]
+}
+
+@test "does not pass --reporter when SWIFTLINT_REPORTER is empty" {
+    export SWIFTLINT_REPORTER=""
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    result=$(cat "${STUB_CALL_LOG}")
+    [[ "${result}" != *"--reporter"* ]]
+}
+
+@test "output includes the running line" {
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Running: swiftlint"* ]]
+}

--- a/tests/scripts/verify_rbenv.bats
+++ b/tests/scripts/verify_rbenv.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/verify_rbenv.sh
+# Note: script has no set -euo pipefail; it uses || fallbacks.
+# It runs ruby -v; if that fails tries rbenv local; then ruby -v + which ruby.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/verify_rbenv.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+
+setup() {
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+}
+
+@test "succeeds when ruby is available" {
+    export PATH="${STUBS}:${PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "outputs ruby version info" {
+    export PATH="${STUBS}:${PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"ruby"* ]]
+}
+
+@test "falls back to rbenv local when ruby not in PATH" {
+    # Use tmpbin with rbenv but not ruby initially
+    TMPBIN="${BATS_TMPDIR}/bin_${BATS_TEST_NUMBER}"
+    mkdir -p "${TMPBIN}"
+    cp "${STUBS}/rbenv" "${TMPBIN}/rbenv"
+    chmod +x "${TMPBIN}/rbenv"
+    # Create a ruby stub that fails on first call (simulating not found),
+    # succeeds on subsequent calls after rbenv local sets it up
+    CALL_COUNT_FILE="${BATS_TMPDIR}/ruby_calls_${BATS_TEST_NUMBER}"
+    echo "0" > "${CALL_COUNT_FILE}"
+    cat > "${TMPBIN}/ruby" << RUBYSTUB
+#!/usr/bin/env bash
+COUNT=\$(cat "${CALL_COUNT_FILE}")
+COUNT=\$((COUNT+1))
+echo "\$COUNT" > "${CALL_COUNT_FILE}"
+if [ "\$COUNT" -eq 1 ]; then
+    exit 1
+fi
+echo "ruby 3.2.0 (stub)"
+RUBYSTUB
+    chmod +x "${TMPBIN}/ruby"
+    export PATH="${TMPBIN}:${PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^rbenv" "${STUB_CALL_LOG}"
+}

--- a/tests/scripts/xcodegen_generate.bats
+++ b/tests/scripts/xcodegen_generate.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/xcodegen_generate.sh
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/xcodegen_generate.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+
+setup() {
+    export PATH="${STUBS}:${PATH}"
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+    export XCODEGEN_SPEC="project.yml"
+    export XCODEGEN_QUIET="false"
+}
+
+@test "runs xcodegen generate with spec" {
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^xcodegen generate --spec project.yml$" "${STUB_CALL_LOG}"
+}
+
+@test "adds --quiet when XCODEGEN_QUIET=true" {
+    export XCODEGEN_QUIET=true
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^xcodegen generate --spec project.yml --quiet$" "${STUB_CALL_LOG}"
+}
+
+@test "does not add --quiet when XCODEGEN_QUIET=false" {
+    export XCODEGEN_QUIET=false
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    result=$(grep "^xcodegen generate" "${STUB_CALL_LOG}")
+    [[ "${result}" != *"--quiet"* ]]
+}
+
+@test "uses custom spec path" {
+    export XCODEGEN_SPEC="custom/spec.yml"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^xcodegen generate --spec custom/spec.yml$" "${STUB_CALL_LOG}"
+}
+
+@test "output includes running line" {
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"Running: xcodegen generate"* ]]
+}

--- a/tests/scripts/xcodegen_install.bats
+++ b/tests/scripts/xcodegen_install.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# Tests for src/scripts/xcodegen_install.sh
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../src/scripts/xcodegen_install.sh"
+STUBS="${BATS_TEST_DIRNAME}/../stubs"
+SYSTEM_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+setup() {
+    export STUB_CALL_LOG="${BATS_TMPDIR}/calls_${BATS_TEST_NUMBER}.log"
+    rm -f "${STUB_CALL_LOG}"
+}
+
+@test "skips brew when xcodegen already installed" {
+    export PATH="${STUBS}:${SYSTEM_PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"already installed"* ]]
+}
+
+@test "calls brew install when xcodegen absent" {
+    TMPBIN="${BATS_TMPDIR}/bin_${BATS_TEST_NUMBER}"
+    mkdir -p "${TMPBIN}"
+    cp "${STUBS}/brew" "${TMPBIN}/brew"
+    chmod +x "${TMPBIN}/brew"
+    export PATH="${TMPBIN}:${SYSTEM_PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    grep -q "^brew install xcodegen" "${STUB_CALL_LOG}"
+}
+
+@test "reports XcodeGen version when found" {
+    export PATH="${STUBS}:${SYSTEM_PATH}"
+    run bash "${SCRIPT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"XcodeGen"* ]]
+}

--- a/tests/stubs/brew
+++ b/tests/stubs/brew
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "brew stub: $*" >&2
+echo "brew $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+echo "stub:brew $*"

--- a/tests/stubs/bundle
+++ b/tests/stubs/bundle
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "bundle stub: $*" >&2
+echo "bundle $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+echo "stub:bundle $*"

--- a/tests/stubs/git
+++ b/tests/stubs/git
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+echo "git stub: $*" >&2
+echo "git $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+case "$*" in
+    "describe --tags --abbrev=0")
+        echo "v1.2.3"
+        ;;
+    "rev-parse v1.2.4")
+        # Tag does not exist — return non-zero so script proceeds to create it
+        exit 1
+        ;;
+    "rev-parse "*)
+        exit 1
+        ;;
+    "tag -a "*)
+        echo "stub:git tag created"
+        ;;
+    "push origin "*)
+        echo "stub:git push"
+        ;;
+    *)
+        echo "stub:git $*"
+        ;;
+esac

--- a/tests/stubs/rbenv
+++ b/tests/stubs/rbenv
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+echo "rbenv stub: $*" >&2
+echo "rbenv $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+case "$*" in
+    "versions --bare")
+        printf "3.1.0\n3.2.0\n"
+        ;;
+    global)
+        echo "3.2.0"
+        ;;
+    "local "*)
+        echo "stub:rbenv local set"
+        ;;
+    *)
+        echo "stub:rbenv $*"
+        ;;
+esac

--- a/tests/stubs/ruby
+++ b/tests/stubs/ruby
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "ruby stub: $*" >&2
+echo "ruby $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+echo "ruby 3.2.0 (stub)"

--- a/tests/stubs/swift
+++ b/tests/stubs/swift
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+echo "swift stub: $*" >&2
+echo "swift $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+if [[ "$*" == *"--show-bin-path"* ]]; then
+    echo "${STUB_BUILD_DIR:-}"
+fi

--- a/tests/stubs/swiftlint
+++ b/tests/stubs/swiftlint
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "swiftlint stub: $*" >&2
+echo "swiftlint $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+echo "stub:swiftlint $*"

--- a/tests/stubs/xcodebuild
+++ b/tests/stubs/xcodebuild
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+echo "xcodebuild stub: $*" >&2
+echo "xcodebuild $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+if [[ "$*" == *"showBuildSettings"* ]]; then
+    echo "    MARKETING_VERSION = 2.5.0"
+fi

--- a/tests/stubs/xcodegen
+++ b/tests/stubs/xcodegen
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "xcodegen stub: $*" >&2
+echo "xcodegen $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+echo "stub:xcodegen $*"

--- a/tests/stubs/xcresultparser
+++ b/tests/stubs/xcresultparser
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo "xcresultparser stub: $*" >&2
+echo "xcresultparser $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+echo "<?xml version=\"1.0\" ?><coverage version=\"4\"><packages/></coverage>"

--- a/tests/stubs/xcrun
+++ b/tests/stubs/xcrun
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+echo "xcrun stub: $*" >&2
+echo "xcrun $*" >> "${STUB_CALL_LOG:-/tmp/stub_calls.log}"
+# Simulate llvm-cov export writing lcov data to stdout
+if [[ "$*" == *"llvm-cov export"* ]]; then
+    echo "DA:1,1"
+    echo "DA:2,0"
+fi


### PR DESCRIPTION
## Summary
Fixes the empty qlty coverage badge: the orb's 10 bash scripts now have real unit tests (55 bats-core cases, PATH-isolated stubs recording invocations) executed under kcov, merged to cobertura, and published via the qlty orb from a new `script_tests` job (`qlty-credentials` context).

Includes 12 cases on `swiftlint_run.sh` alone — the strict=true/1/unset matrix and the bash-3.2 empty-array guard that bit TrailSync's lint job earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)